### PR TITLE
updating MPI CMakeLists

### DIFF
--- a/apps/mpi/CMakeLists.txt
+++ b/apps/mpi/CMakeLists.txt
@@ -20,9 +20,9 @@ foreach(source_file ${CPP_SOURCES})
   target_include_directories(
     ${exec_name}
     PRIVATE ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/../../include
-            ${ARGPARSE_INCLUDE_DIR} ${MDSPAN_INCLUDE_DIR})
+            ${ARGPARSE_INCLUDE_DIR} ${MDSPAN_INCLUDE_DIR} ${MPI_CXX_HEADER_DIR})
 
-  target_link_libraries(${exec_name} PUBLIC ${MPI_LIBS})
+  target_link_libraries(${exec_name} PUBLIC ${MPI_LIBS} ${MPI_mpi_LIBRARY} ${MPI_mpi_cxx_LIBRARY})
 
   set_target_properties(
     ${exec_name}
@@ -54,9 +54,9 @@ foreach(source_file ${C_SOURCES})
   target_include_directories(
     ${exec_name}
     PRIVATE ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/../../include
-            ${ARGPARSE_INCLUDE_DIR} ${MDSPAN_INCLUDE_DIR})
+            ${ARGPARSE_INCLUDE_DIR} ${MDSPAN_INCLUDE_DIR} ${MPI_CXX_HEADER_DIR})
 
-  target_link_libraries(${exec_name} PUBLIC ${MPI_LIBS})
+  target_link_libraries(${exec_name} PUBLIC ${MPI_LIBS} ${MPI_mpi_LIBRARY})
 
   set_target_properties(
     ${exec_name}

--- a/scripts/build_AMD_HPC_FUND
+++ b/scripts/build_AMD_HPC_FUND
@@ -1,12 +1,13 @@
-#!/bin/bash 
+#!/bin/bash
 
-ROCM_DIR="/opt/rocm-6.0.2/"
 export CC=${ROCM_DIR}/bin/hipcc
 export CXX=${ROCM_DIR}/bin/hipcc
 export NVSHMEM_SHMEM_SUPPORT=OFF
+module use /share/bpotter/modulefiles
+module load rocshmem
 export rocshmem_DIR="/share/bpotter/rocshmem_1.6.3/"
 
 cmake ../	\
       -DCMAKE_CXX_COMPILER=${ROCM_DIR}/bin/hipcc\
       -DUSE_NVSHMEM=OFF\
-      -DCMAKE_CUDA_HOST_COMPILER=${ROCM_DIR}/bin/hipcc	
+      -DCMAKE_CUDA_HOST_COMPILER=${ROCM_DIR}/bin/hipcc


### PR DESCRIPTION
I had to add the lib/include directories in cmake for the MPI apps to compile on the AMD cluster, though it may not be needed for the rocshmem applications. 