### PR TITLE
Add the atomic compare-and-swap benchmark with ROCSHMEM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+run/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 run/
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 build/
-run/
 .vscode/

--- a/apps/mpi/CMakeLists.txt
+++ b/apps/mpi/CMakeLists.txt
@@ -20,9 +20,9 @@ foreach(source_file ${CPP_SOURCES})
   target_include_directories(
     ${exec_name}
     PRIVATE ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/../../include
-            ${ARGPARSE_INCLUDE_DIR} ${MDSPAN_INCLUDE_DIR})
+            ${ARGPARSE_INCLUDE_DIR} ${MDSPAN_INCLUDE_DIR} ${MPI_CXX_HEADER_DIR})
 
-  target_link_libraries(${exec_name} PUBLIC ${MPI_LIBS})
+  target_link_libraries(${exec_name} PUBLIC ${MPI_LIBS} ${MPI_mpi_LIBRARY} ${MPI_mpi_cxx_LIBRARY})
 
   set_target_properties(
     ${exec_name}
@@ -54,9 +54,9 @@ foreach(source_file ${C_SOURCES})
   target_include_directories(
     ${exec_name}
     PRIVATE ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/../../include
-            ${ARGPARSE_INCLUDE_DIR} ${MDSPAN_INCLUDE_DIR})
+            ${ARGPARSE_INCLUDE_DIR} ${MDSPAN_INCLUDE_DIR} ${MPI_CXX_HEADER_DIR})
 
-  target_link_libraries(${exec_name} PUBLIC ${MPI_LIBS})
+  target_link_libraries(${exec_name} PUBLIC ${MPI_LIBS} ${MPI_mpi_LIBRARY})
 
   set_target_properties(
     ${exec_name}

--- a/apps/rocshmem/shmem_atomic_cas_bw.cpp
+++ b/apps/rocshmem/shmem_atomic_cas_bw.cpp
@@ -1,0 +1,37 @@
+#include "xmr.hpp"
+#include "commons/mpi.hpp"
+#include "commons/hip.hpp"
+#include "commons/rocshmem.hpp"
+
+int main(int argc, char *argv[]) {
+  int mype, npes;
+
+  hipEvent_t start, stop;
+
+  int rank, nranks;
+  MPI_CHECK(MPI_Init(&argc, &argv));
+  MPI_CHECK(MPI_Comm_rank(MPI_COMM_WORLD, &rank));
+  MPI_CHECK(MPI_Comm_size(MPI_COMM_WORLD, &nranks));
+  //printf("Rank %d, MPI \n", rank);
+
+  // Set the device before calling `roc_shmem_init`
+  int ndevices, get_cur_dev;
+  CHECK_HIP(hipGetDeviceCount(&ndevices));
+  CHECK_HIP(hipSetDevice(rank % ndevices));
+  CHECK_HIP(hipGetDevice(&get_cur_dev));
+
+  printf("Device ID %d, HIP \n", get_cur_dev);
+
+  CHECK_HIP(hipEventCreate(&start));
+  CHECK_HIP(hipEventCreate(&stop));
+
+  roc_shmem_init();
+  mype = roc_shmem_my_pe();
+  npes = roc_shmem_n_pes();
+  printf("Rank %d, ROC_SHMEM \n", mype);
+  fflush(stdout);
+
+  roc_shmem_finalize();
+  MPI_Finalize();
+  return 0;
+}

--- a/apps/rocshmem/shmem_atomic_cas_bw.cpp
+++ b/apps/rocshmem/shmem_atomic_cas_bw.cpp
@@ -10,7 +10,7 @@
 #define MAX_SKIP 10
 #define THREADS 1024
 #define BLOCKS 4
-#define MAX_MSG_SIZE 64 * 1024
+#define MAX_MSG_SIZE (32 * 1024 * 1024)
 
 __global__ void atomic_compare_swap_bw(
     uint64_t *data_d, volatile unsigned int *counter_d, int len, int pe, int iter) {
@@ -144,7 +144,7 @@ int main(int argc, char *argv[]) {
   int size;
   i = 0;
   if (mype == 0) {
-    for (size = 1024; size <= MAX_MSG_SIZE; size *= 2) {
+    for (size = 8; size <= MAX_MSG_SIZE; size *= 2) {
 
       int blocks = max_blocks, threads = max_threads;
 
@@ -175,7 +175,7 @@ int main(int argc, char *argv[]) {
       roc_shmem_barrier_all();
     }
   }  else {
-    for (size = 1024; size <= MAX_MSG_SIZE; size *= 2) {
+    for (size = 8; size <= MAX_MSG_SIZE; size *= 2) {
       roc_shmem_barrier_all();
       roc_shmem_barrier_all();
       roc_shmem_barrier_all();

--- a/apps/rocshmem/shmem_atomic_cas_bw.cpp
+++ b/apps/rocshmem/shmem_atomic_cas_bw.cpp
@@ -120,6 +120,8 @@ int main(int argc, char *argv[]) {
   fflush(stdout);
 
   if (argc > 1) {
+    // mypeer is unused, keeping it to match other tests
+    // device 1 is used as the peer
     int mypeer = atoi(argv[1]);
     if (atoi(argv[2]) > 0) max_blocks = atoi(argv[2]);
     if (atoi(argv[3]) > 0) max_threads = atoi(argv[3]);
@@ -154,7 +156,7 @@ int main(int argc, char *argv[]) {
       CHECK_HIP(hipDeviceSynchronize());
       roc_shmem_barrier_all();
 
-      /* reset values in code. */
+      // reset values in code
       CHECK_HIP(hipMemset(counter_d, 0, sizeof(unsigned int) * 2));
       CHECK_HIP(hipGetLastError());
       CHECK_HIP(hipDeviceSynchronize());

--- a/include/commons/hip.hpp
+++ b/include/commons/hip.hpp
@@ -1,0 +1,9 @@
+#define CHECK_HIP(cmd)                                                        \
+  {                                                                           \
+    hipError_t error = cmd;                                                   \
+    if (error != hipSuccess) {                                                \
+      fprintf(stderr, "error: '%s'(%d) at %s:%d\n", hipGetErrorString(error), \
+              error, __FILE__, __LINE__);                                     \
+      exit(EXIT_FAILURE);                                                     \
+    }                                                                         \
+  }

--- a/scripts/build_AMD_HPC_FUND
+++ b/scripts/build_AMD_HPC_FUND
@@ -1,12 +1,13 @@
-#!/bin/bash 
+#!/bin/bash
 
-ROCM_DIR="/opt/rocm-6.0.2/"
 export CC=${ROCM_DIR}/bin/hipcc
 export CXX=${ROCM_DIR}/bin/hipcc
 export NVSHMEM_SHMEM_SUPPORT=OFF
+module use /share/bpotter/modulefiles
+module load rocshmem
 export rocshmem_DIR="/share/bpotter/rocshmem_1.6.3/"
 
 cmake ../	\
       -DCMAKE_CXX_COMPILER=${ROCM_DIR}/bin/hipcc\
       -DUSE_NVSHMEM=OFF\
-      -DCMAKE_CUDA_HOST_COMPILER=${ROCM_DIR}/bin/hipcc	
+      -DCMAKE_CUDA_HOST_COMPILER=${ROCM_DIR}/bin/hipcc


### PR DESCRIPTION
It is ported from the corresponding NVSHMEM perftest after modifying for simplicity and correcting a bug. It is currently set up to be run with two ranks/devices, and does not loop over multiple peers like the other benchmarks.

This PR also includes changes to the CMake setup to allow compiling the MPI apps on the AMD HPC fund.

And finally minor changes to the template build script and adding a gitignore file.