### PR TITLE
Solve jacobi roc_shmem issue for large problem sizes

### DIFF
--- a/apps/rocshmem/jacobi_rocshmem_opt.cpp
+++ b/apps/rocshmem/jacobi_rocshmem_opt.cpp
@@ -547,8 +547,8 @@ double single_gpu(const int nx, const int ny, const int iter_max, real* const a_
             "check every %d iterations\n",
             iter_max, ny, nx, nccheck);
 
-    constexpr int dim_block_x = 1024;
-    constexpr int dim_block_y = 1;
+    constexpr int dim_block_x = 32;
+    constexpr int dim_block_y = 32;
     dim3 dim_grid((nx + dim_block_x - 1) / dim_block_x, ((ny - 2) + dim_block_y - 1) / dim_block_y,
                   1);
 

--- a/apps/rocshmem/jacobi_rocshmem_opt.cpp
+++ b/apps/rocshmem/jacobi_rocshmem_opt.cpp
@@ -218,8 +218,9 @@ int main(int argc, char* argv[]) {
     long long unsigned int mesh_size_per_rank = nx * (((ny - 2) + size - 1) / size + 2);
     long long unsigned int required_symmetric_heap_size =
         2 * mesh_size_per_rank * sizeof(real) *
-        1.1;  // Factor 2 is because 2 arrays are allocated - a and a_new
-              // 1.1 factor is just for alignment or other usage
+        4.0;  // Factor 2 is because 2 arrays are allocated - a and a_new
+              // 4.0 factor is just for alignment or other usage
+              // it was the minimum factor required to make it work on the AMD Fund
 
     char * value = getenv("ROC_SHMEM_HEAP_SIZE");
     if (value) { /* env variable is set */


### PR DESCRIPTION
Main changes
- implementing the ROC_SHMEM_HEAP_SIZE to allow larger problem sizes. Note that I had to tweak the "multiplication factor" for calculating the size for certain no. of GPUs (trial and error). So this is something which is still finicky and we should ask the AMD staff about it.
- change grid to 32x32 rather than 1024x1 (this is why serial version was slow earlier)
- switch to using the "simple" jacobi kernel rather than the block comms one as it was faster (on the AMD Fund with the problem sizes I tested).