### PR TITLE
Add basic build for Intel SHMEM and Jacobi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,9 @@ endif()
 ##########################################################################################
 #       Check and set CMAKE_CUDA_HOST_COMPILER
 ##########################################################################################
-if(NOT DEFINED CMAKE_CUDA_HOST_COMPILER)
+option(USE_CUDA "Enable CUDA.." ON)
+
+if(NOT DEFINED CMAKE_CUDA_HOST_COMPILER AND USE_CUDA)
     message(STATUS "CMAKE_CUDA_HOST_COMPILER not provided\n=> Setting CMAKE_CUDA_HOST_COMPILER=$(which CC)")
 
     # run which CC to find the CUDA_HOST_COMPILER
@@ -110,8 +112,6 @@ endif()
 
 set(NVSHMEM_PREFIX $ENV{NVSHMEM_PREFIX} CACHE PATH "path to NVSHMEM install directory.")
 set(CUDA_HOME $ENV{CUDA_HOME} CACHE PATH "path to CUDA installation")
-set(MPI_HOME $ENV{MPI_HOME} CACHE PATH "path to MPI installation")
-set(SHMEM_HOME ${MPI_HOME} CACHE PATH "path to SHMEM installation")
 set(CUDA_ARCHITECTURES $ENV{CUDA_ARCHITECTURES} CACHE PATH "CUDA architectures to build for")
 
 option(NVSHMEM_MPI_SUPPORT "Enable compilation of the MPI bootstrap and MPI-specific code" ${NVSHMEM_MPI_SUPPORT_DEFAULT})
@@ -121,6 +121,31 @@ option(NVSHMEM_VERBOSE "Enable the ptxas verbose compilation option" OFF)
 if (USE_NVSHMEM)
     find_package(NVSHMEM REQUIRED HINTS ${NVSHMEM_PREFIX}/lib/cmake/nvshmem)
 endif()
+
+##########################################################################################
+#       ISHMEM settings
+##########################################################################################
+option(USE_ISHMEM "Enable ISHMEM.." OFF)
+
+if (DEFINED ENV{ISHMEM_MPI_SUPPORT})
+    set(ISHMEM_MPI_SUPPORT_DEFAULT $ENV{ISHMEM_MPI_SUPPORT})
+else()
+    set(ISHMEM_MPI_SUPPORT_DEFAULT OFF)
+endif()
+
+set(ISHMEM_PREFIX $ENV{ISHMEM_ROOT} CACHE PATH "path to ISHMEM install directory.")
+option(ISHMEM_MPI_SUPPORT "Enable compilation of the MPI bootstrap and MPI-specific code" ${ISHMEM_MPI_SUPPORT_DEFAULT})
+
+if (USE_ISHMEM)
+    set(ISHMEM_SHMEM_SUPPORT "Enable Compilation of the SHMEM bootstrap and SHMEM specific code" ON)
+    find_package(ISHMEM REQUIRED)
+    set(CMAKE_CXX_COMPILER oshc++)
+    add_compile_options(-fsycl)
+    add_link_options(-fsycl)
+endif()
+
+set(MPI_HOME $ENV{MPI_HOME} CACHE PATH "path to MPI installation")
+set(SHMEM_HOME ${SHMEM_HOME} CACHE PATH "path to SHMEM installation")
 
 ##########################################################################################
 #       Setup CUDA and MPI for aliases
@@ -141,25 +166,14 @@ set(CMAKE_CUDA_ARCHITECTURES ${CUDA_ARCHITECTURES})
 #       SHMEM support
 ##########################################################################################
 
-if(NVSHMEM_SHMEM_SUPPORT)
-    find_library(
-      SHMEM_LIB
-      NAMES oshmem
-      HINTS ${SHMEM_HOME}
-      PATH_SUFFIXES lib lib64)
-
-    find_path(SHMEM_INCLUDE NAME shmem.h HINTS ${SHMEM_HOME}
-              PATH_SUFFIXES include)
-
-    add_library(shmem IMPORTED INTERFACE)
-    target_link_libraries(shmem INTERFACE ${SHMEM_LIB})
-    target_include_directories(shmem INTERFACE ${SHMEM_INCLUDE})
+if(NVSHMEM_SHMEM_SUPPORT OR ISHMEM_SHMEM_SUPPORT)
+    find_package(SHMEM REQUIRED)
 
     if(NVSHMEM_MPI_SUPPORT)
           separate_arguments(SHMEM_C_LINK_FLAGS NATIVE_COMMAND "${MPI_C_LINK_FLAGS}")
-          target_link_options(shmem INTERFACE ${SHMEM_C_LINK_FLAGS})
-          target_compile_definitions(shmem INTERFACE ${MPI_C_COMPILE_DEFINITIONS})
-          target_compile_options(shmem INTERFACE ${MPI_C_COMPILE_OPTIONS})
+          target_link_options(SHMEM INTERFACE ${SHMEM_C_LINK_FLAGS})
+          target_compile_definitions(SHMEM INTERFACE ${MPI_C_COMPILE_DEFINITIONS})
+          target_compile_options(SHMEM INTERFACE ${MPI_C_COMPILE_OPTIONS})
     endif()
 endif()
 

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,275 @@
+The CMake modules in the "external" directory originate from the Kokkos Remote
+Spaces project: https://github.com/kokkos/kokkos-remote-spaces
+under the Apache License v2.0 with LLVM Exceptions:
+
+ ************************************************************************
+
+                        Kokkos v. 4.0
+       Copyright (2022) National Technology & Engineering
+               Solutions of Sandia, LLC (NTESS).
+
+ Under the terms of Contract DE-NA0003525 with NTESS,
+ the U.S. Government retains certain rights in this software.
+
+
+ ==============================================================================
+ Kokkos is under the Apache License v2.0 with LLVM Exceptions:
+ ==============================================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS Apache 2.0
+
+ ---- LLVM Exceptions to the Apache 2.0 License ----
+
+ As an exception, if, as a result of your compiling your source code, portions
+ of this Software are embedded into an Object form of such source code, you
+ may redistribute such embedded portions in such Object form without complying
+ with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+ In addition, if you combine or link compiled forms of this Software with
+ software that is licensed under the GPLv2 ("Combined Software") and if a
+ court of competent jurisdiction determines that the patent provision (Section
+ 3), the indemnity provision (Section 9) or other Section of the License
+ conflicts with the conditions of the GPLv2, you may retroactively and
+ prospectively choose to deem waived or otherwise exclude such Section(s) of
+ the License, but only in their entirety and only with respect to the Combined
+ Software.
+
+ ==============================================================================
+ Software from third parties included in Kokkos:
+ ==============================================================================
+
+ Kokkos contains third party software which is under different license
+ terms. All such code will be identified clearly using at least one of two
+ mechanisms:
+ 1) It will be in a separate directory tree with its own `LICENSE.txt` or
+    `LICENSE` file at the top containing the specific license and restrictions
+    which apply to that software, or
+ 2) It will contain specific license and restriction terms at the top of every
+    file.
+
+
+ THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ Questions? Contact:
+   Christian R. Trott (crtrott@sandia.gov) and
+   Damien T. Lebrun-Grandie (lebrungrandt@ornl.gov)
+
+ ************************************************************************
+
+Intel® SHMEM apps are provided under the BSD-3-Clause license:
+
+Copyright (c) 2024 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+“AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+SPDX-License-Identifier: BSD-3-Clause

--- a/README.md
+++ b/README.md
@@ -4,7 +4,20 @@
 # Copyright
 The NVSHMEM and NCCL jacobi code is from https://github.com/NVIDIA/multi-gpu-programming-models.git. Copyright (c) 2017, NVIDIA CORPORATION. All rights reserved.
 
+See the COPYRIGHT file for more information on any additional dependencies.
+
 # ROC_SHMEM and RCCL
 The ROC_SHMEM and RCCL code are modified from NVIDIA versions.
 
-
+# Intel® SHMEM
+To build the Intel SHMEM applications, please disable CUDA and NVSHMEM, then
+set `ISHMEM_ROOT` to the installation directory of Intel SHMEM and `SHMEM_ROOT`
+to the installation directory of a host OpenSHMEM runtime (as of this writing,
+Sandia OpenSHMEM is required).  Please set `CXX` to the `oshc++` compiler
+wrapper. The following was tested on Intel® Tiber™ AI Cloud with Intel® Max
+Series GPU (PVC) on 4th Gen Intel® Xeon® processors – 1550 series (8x) with
+machine image Ubuntu 22.04 LTS (Jammy Jellyfish) v20240522:
+```
+CXX=oshc++ cmake .. -DUSE_CUDA=OFF -DUSE_NVSHMEM=OFF -DUSE_ISHMEM=ON -DISHMEM_ROOT=$ISHMEM_ROOT -DSHMEM_ROOT=$SHMEM_ROOT
+mpirun -n 16 ishmrun ./apps/ishmem/jacobi
+```

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 # Add mpi apps
 # ----------------------------------------------------------------------------------------#
 
+if (NOT USE_ISHMEM)
 message(STATUS "Adding mpi apps...")
 add_subdirectory(mpi)
 
@@ -27,3 +28,13 @@ add_subdirectory(rocshmem)
 
 message(STATUS "Adding rccl apps...")
 add_subdirectory(rccl)
+endif()
+
+# ----------------------------------------------------------------------------------------#
+# Add ishmem apps
+# ----------------------------------------------------------------------------------------#
+
+if (USE_ISHMEM)
+    message(STATUS "Adding ishmem apps...")
+    add_subdirectory(ishmem)
+endif()

--- a/apps/ishmem/CMakeLists.txt
+++ b/apps/ishmem/CMakeLists.txt
@@ -1,0 +1,23 @@
+# each .cpp file is a new target
+file(GLOB ISHMEM_APP_SOURCES "*.cpp")
+
+# loop through all source files
+foreach(source_file ${ISHMEM_APP_SOURCES})
+
+    # get file name
+    get_filename_component(NAME_ ${source_file} NAME_WE)
+
+    # add a new target
+    add_executable(${NAME_} ${source_file})
+
+    # link and include dependency libraries 
+    target_link_libraries(${NAME_} PRIVATE SHMEM)
+    target_link_libraries(${NAME_} PRIVATE ISHMEM)
+    target_include_directories(${NAME_} PRIVATE SHMEM)
+    target_include_directories(${NAME_} PRIVATE ISHMEM)
+    target_link_options(${NAME_} PRIVATE -lze_loader)
+
+    # install
+    install(TARGETS ${NAME_} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+endforeach()

--- a/apps/ishmem/jacobi.cpp
+++ b/apps/ishmem/jacobi.cpp
@@ -1,0 +1,329 @@
+/* Copyright (C) 2023 Intel Corporation
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/* Copyright (c) 2017-2018, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <iostream>
+#include <chrono>
+#include <cmath>
+#include <algorithm>
+#include <sstream>
+#include <vector>
+#include <CL/sycl.hpp>
+#include <shmem.h>
+#include <ishmem.h>
+#include <ishmemx.h>
+
+typedef float real;
+constexpr real tol = 1.0e-4f;
+constexpr int max_iter_max = 10000000;
+
+using std::sin, std::sinh;
+using std::chrono::high_resolution_clock, std::chrono::microseconds;
+const real PI = static_cast<real>(2.0 * std::asin(1.0));
+
+template <typename T>
+T get_argval(char **begin, char **end, const std::string &arg, const T default_val)
+{
+    T argval = default_val;
+    char **itr = std::find(begin, end, arg);
+    if (itr != end && ++itr != end) {
+        std::istringstream inbuf(*itr);
+        inbuf >> argval;
+    }
+    return argval;
+}
+
+void init_boundaries(real *__restrict__ const a, real *__restrict__ const a_new, const real pi,
+                     const int offset, const int nx, const int my_ny, const int ny, sycl::queue &q)
+{
+    q.parallel_for(static_cast<size_t>(my_ny), [=](sycl::id<1> iy) {
+         const real y0 =
+             sycl::sin(2.0f * pi * (static_cast<real>(offset + iy) / static_cast<real>(ny - 1)));
+         a[(iy + 1) * nx + 0] = y0;
+         a[(iy + 1) * nx + (nx - 1)] = y0;
+         a_new[(iy + 1) * nx + 0] = y0;
+         a_new[(iy + 1) * nx + (nx - 1)] = y0;
+     }).wait_and_throw();
+}
+
+sycl::event jacobi_kernel(real *__restrict__ const a_new, real *__restrict__ const a,
+                          real *__restrict__ const l2_norm_d, const int iy_start, const int iy_end,
+                          const int nx, const int top_pe, const int top_iy, const int bottom_pe,
+                          const int bottom_iy, sycl::queue &q, std::vector<sycl::event> event_waits,
+                          int global_range)
+{
+    // TODO: try-catch added to resolve issue detected by Coverity. More robust
+    // error handling to be implemented later.
+    try {
+        auto sum_red = sycl::reduction(l2_norm_d, sycl::plus<>());
+        auto ret = q.parallel_for(
+            sycl::range<1>{static_cast<size_t>(global_range)}, sum_red,
+            [=](sycl::id<1> idx, auto &sumr) {
+                int iy = static_cast<int>(idx) / nx + iy_start;
+                int ix = static_cast<int>(idx) % nx + 1;
+                real local_norm = static_cast<real>(0.0);
+
+                if (iy < iy_end && ix < (nx - 1)) {
+                    const real new_val =
+                        static_cast<real>(0.25) * (a[iy * nx + ix + 1] + a[iy * nx + ix - 1] +
+                                                   a[(iy + 1) * nx + ix] + a[(iy - 1) * nx + ix]);
+                    a_new[iy * nx + ix] = new_val;
+
+                    // apply boundary conditions
+                    if (iy_start == iy) {
+                        ishmem_float_p((real *) (a_new + top_iy * nx + ix), new_val, top_pe);
+                    }
+
+                    if (iy_end - 1 == iy) {
+                        ishmem_float_p((real *) (a_new + bottom_iy * nx + ix), new_val, bottom_pe);
+                    }
+
+                    real residue = a[iy * nx + ix] - new_val;
+                    local_norm = residue * residue;
+                    sumr += local_norm;
+                }
+            });
+        return ret;
+    } catch (sycl::exception &e) {
+        std::cout << e.what() << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+// Exact solution to the laplace equation for the given boundary condition
+// Assuming length in x direction = length in y direction, which is true for
+// only square grids
+void check_solution(real *const A, const int nx, const int ny, const int iy_start_global,
+                    const int iy_end_global, const int pe)
+{
+    // If the grid is not fine enough, numerical errors are significant
+    // Disable the check in that case.
+    const real check_tol = static_cast<real>(0.05);
+    if (nx < 64 || ny < 64 || nx != ny) return;
+    int ny_in = ny - 2;
+    for (int iy = iy_start_global; iy < iy_end_global; iy++)
+        for (int ix = 0; ix < nx; ix++) {
+            const real x = (static_cast<real>(ix) / static_cast<real>(nx - 1));
+            const real y = (static_cast<real>(iy) / static_cast<real>(ny_in - 1));
+            const real val =
+                sin(2 * PI * y) * (sinh(2 * PI * x) + sinh(2 * PI * (1 - x))) / sinh(2 * PI);
+
+            if (std::fabs(A[(iy + 1) * nx + ix] - val) > check_tol) {
+                std::cerr << "Numerical solution " << A[(iy + 1) * nx + ix]
+                          << " does not match the exact solution " << val << " at row = " << iy
+                          << "and column = " << ix << std::endl;
+                return;
+            }
+        }
+
+    if (pe == 0) std::cout << "Numerical solution matches the exact solution" << std::endl;
+}
+
+int main(int argc, char *argv[])
+{
+    int iter_max = get_argval<int>(argv, argv + argc, "-niter", 10000);
+    int nx = get_argval<int>(argv, argv + argc, "-nx", 128);
+    int ny = get_argval<int>(argv, argv + argc, "-ny", 128);
+    // TODO: use a size of 16384 in performance testing
+
+    if (iter_max < 1 || iter_max > max_iter_max) {
+        std::cout << "Invalid input: iter_max";
+        return EXIT_FAILURE;
+    }
+
+    if (nx < 1 || ny < 1) {
+        std::cout << "Invalid input: grid_size";
+        return EXIT_FAILURE;
+    }
+
+    const int nccheck = 1;
+    sycl::queue Q;
+
+    ishmem_init();
+
+    int mype = shmem_my_pe();
+    int npes = shmem_n_pes();
+
+    // ny - 2 rows are distributed amongst `size` ranks in such a way
+    // that each rank gets either (ny - 2) / size or (ny - 2) / size + 1 rows.
+    // This optimizes load balancing when (ny - 2) % size != 0
+    int chunk_size;
+    int chunk_size_low = (ny - 2) / npes;
+    int chunk_size_high = chunk_size_low + 1;
+    // To calculate the number of ranks that need to compute an extra row,
+    // the following formula is derived from this equation:
+    // num_ranks_low * chunk_size_low + (size - num_ranks_low) * (chunk_size_low + 1) = ny - 2
+    int num_ranks_low =
+        npes * static_cast<int>(chunk_size_low) + npes -
+        static_cast<int>(ny - 2);  // Number of ranks with chunk_size = chunk_size_low
+
+    if (mype < num_ranks_low) chunk_size = chunk_size_low;
+    else chunk_size = chunk_size_high;
+
+    sycl::event compute_done[2], compute_barrier_done[2], reset_l2_norm_done[2],
+        copy_l2_norm_done[2];
+    real *a_ref_h = sycl::malloc_host<real>(static_cast<size_t>(nx * ny), Q);
+    real *a_h = sycl::malloc_host<real>(static_cast<size_t>(nx * ny), Q);
+    real *a = (real *) ishmem_calloc(static_cast<size_t>(nx * (chunk_size_high + 2)), sizeof(real));
+    real *a_new =
+        (real *) ishmem_calloc(static_cast<size_t>(nx * (chunk_size_high + 2)), sizeof(real));
+    real *l2_norms_d = sycl::malloc_device<real>(2, Q);
+    real *l2_norms_h = (real *) shmem_malloc(2 * sizeof(real));
+    real *l2_norms = (real *) shmem_malloc(2 * sizeof(real));
+
+    Q.memset(a_ref_h, 0, static_cast<size_t>(nx * ny) * sizeof(real));
+    Q.memset(a_h, 0, static_cast<size_t>(nx * ny) * sizeof(real));
+    Q.memset(l2_norms_d, 0, 2 * sizeof(real));
+    l2_norms_h[0] = 1;
+    l2_norms_h[1] = 1;
+    Q.wait();
+
+    // Calculate local domain boundaries
+    int iy_start_global;  // My start index in the global array
+    if (mype < num_ranks_low) {
+        iy_start_global = mype * chunk_size_low + 1;
+    } else {
+        iy_start_global =
+            num_ranks_low * chunk_size_low + (mype - num_ranks_low) * chunk_size_high + 1;
+    }
+
+    int iy_end_global = iy_start_global + chunk_size - 1;  // My last index in the global array
+    // do not process boundaries
+    iy_end_global = std::min(iy_end_global, ny - 3);
+
+    int iy_start = (mype == 0) ? 2 : 1;
+    int iy_end = iy_end_global - iy_start_global + 2;
+    // calculate boundary indices for top and bottom boundaries
+    int top_pe = mype > 0 ? mype - 1 : (npes - 1);
+    int bottom_pe = (mype + 1) % npes;
+
+    int iy_end_top = (top_pe < num_ranks_low) ? chunk_size_low + 1 : chunk_size_high + 1;
+    int iy_start_bottom = 0;
+
+    // Set Dirichlet boundary conditions on left and right boundary
+    init_boundaries(a, a_new, PI, iy_start_global - 1, nx, chunk_size, ny - 2, Q);
+
+    int iter = 0;
+
+    real err = 0;
+    bool l2_norm_greater_than_tol = true;
+    constexpr int local_x = 32;
+    constexpr int local_y = 32;
+
+    int global_x = ((nx + local_x - 1) / local_x) * local_x;
+    int global_y = ((chunk_size + local_y - 1) / local_y) * local_y;
+    int global_range = global_x * global_y;
+
+    shmem_barrier_all();
+
+    auto time_start = high_resolution_clock::now();
+
+    while (l2_norm_greater_than_tol && iter < iter_max) {
+        // on new iteration: old current vars are now previous vars, old
+        // previous vars are no longer needed
+        int prev = iter % 2;
+        int curr = (iter + 1) % 2;
+        compute_done[curr] =
+            jacobi_kernel(a_new, a, &l2_norms_d[curr], iy_start, iy_end, nx, top_pe, iy_end_top,
+                          bottom_pe, iy_start_bottom, Q,
+                          {compute_barrier_done[prev], reset_l2_norm_done[curr]}, global_range);
+
+        compute_barrier_done[curr] = Q.submit([&](sycl::handler &h) {
+            h.depends_on(compute_done[curr]);
+            h.single_task([=]() { ishmem_barrier_all(); });
+        });
+
+        if ((iter % nccheck) == 0) {
+            copy_l2_norm_done[curr] = Q.submit([&](sycl::handler &h) {
+                h.depends_on(compute_done[curr]);
+                h.memcpy(&l2_norms_h[curr], &l2_norms_d[curr], sizeof(real));
+            });
+
+            copy_l2_norm_done[prev].wait();
+
+            shmem_float_sum_reduce(SHMEM_TEAM_WORLD, &l2_norms[prev], &l2_norms_h[prev], 1);
+
+            l2_norms[prev] = std::sqrt(l2_norms[prev]);
+            l2_norm_greater_than_tol = (l2_norms[prev] > tol);
+
+            if ((iter % 100) == 0) {
+                if (!mype) printf("%5d, %0.6f\n", iter, l2_norms[prev]);
+            }
+            // reset everything for next iteration
+            err = l2_norms[prev];
+            l2_norms[prev] = static_cast<real>(0.0);
+            l2_norms_h[prev] = static_cast<real>(0.0);
+            reset_l2_norm_done[prev] = Q.memset(&l2_norms_d[prev], 0, sizeof(real));
+        }
+
+        std::swap(a_new, a);
+        iter++;
+    }
+
+    Q.wait();
+    shmem_barrier_all();
+
+    auto time_end = high_resolution_clock::now();
+
+    if (mype == 0 && !l2_norm_greater_than_tol)
+        std::cout << "Solution converged within tolerance " << tol << std::endl;
+    else if (mype == 0) std::cout << "Solution unconverged!" << std::endl;
+
+    auto duration = std::chrono::duration_cast<microseconds>(time_end - time_start);
+    if (mype == 0)
+        std::cout << "Time per iteration for " << nx << " x " << ny
+                  << " grid = " << (static_cast<int>(duration.count()) / iter) << "us/iteration"
+                  << std::endl;
+
+    Q.memcpy(
+         a_h + iy_start_global * nx, a + nx,
+         static_cast<size_t>(std::min(ny - 2 - iy_start_global, chunk_size) * nx) * sizeof(real))
+        .wait();
+
+    if (!mype) {
+        printf("l2_norms %16.15f iter %d\n", err, iter);
+        printf("Num GPUs: %d\n", npes);
+        printf("%d x %d: 1 GPU\n", ny, nx);
+    }
+
+    check_solution(a_h, nx, ny, iy_start_global, iy_end_global, mype);
+
+    free(a_ref_h, Q);
+    free(a_h, Q);
+    ishmem_free(a_new);
+    ishmem_free(a);
+    free(l2_norms_d, Q);
+    shmem_free(l2_norms_h);
+    shmem_free(l2_norms);
+
+    ishmem_finalize();
+    shmem_finalize();
+    return EXIT_SUCCESS;
+}

--- a/external/FindISHMEM.cmake
+++ b/external/FindISHMEM.cmake
@@ -1,0 +1,12 @@
+find_library(ishmem_lib_found ishmem PATHS ${ISHMEM_ROOT} SUFFIXES lib lib64 NO_DEFAULT_PATHS)
+find_path(ishmem_headers_found ishmem.h PATHS ${ISHMEM_ROOT}/include NO_DEFAULT_PATHS)
+
+find_package_handle_standard_args(ISHMEM DEFAULT_MSG ishmem_lib_found ishmem_headers_found)
+
+if (ishmem_lib_found AND ishmem_headers_found)
+  add_library(ISHMEM INTERFACE)
+  set_target_properties(ISHMEM PROPERTIES
+    INTERFACE_LINK_LIBRARIES ${ishmem_lib_found}
+    INTERFACE_INCLUDE_DIRECTORIES ${ishmem_headers_found}
+  )
+endif()

--- a/external/FindSHMEM.cmake
+++ b/external/FindSHMEM.cmake
@@ -1,0 +1,13 @@
+find_library(shlib_found NAMES oshmem sma PATHS ${SHMEM_ROOT} SUFFIXES lib lib64 NO_DEFAULT_PATHS)
+find_path(shhdr_found shmem.h PATHS ${SHMEM_ROOT}/include NO_DEFAULT_PATHS)
+
+include (FindPackageHandleStandardArgs)
+find_package_handle_standard_args(SHMEM DEFAULT_MSG shlib_found shhdr_found)
+
+if (shlib_found AND shhdr_found)
+  add_library(SHMEM INTERFACE)
+  set_target_properties(SHMEM PROPERTIES
+    INTERFACE_LINK_LIBRARIES ${shlib_found}
+    INTERFACE_INCLUDE_DIRECTORIES ${shhdr_found}
+  )
+endif()


### PR DESCRIPTION
This adds a basic build for the Jacobi app using Intel SHMEM.

Regarding the formalities with the license/copyright; Intel contributions simply require this official documentation.  I also derived some CMake from Kokkos-Remote-Spaces so included their Apache License v2.0 w/ LLVM Exceptions.  Please let me know what improvements I can make via pull request code review.